### PR TITLE
Add optional confirm dialog for deleting files and folders.

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
                             <input type="checkbox" id="chkVersions" />
                             <label for="chkVersions">Show Versions</label>
                         </div>
+                        <div class="form-group">
+                            <input type="checkbox" id="chkConfirm" />
+                            <label for="chkConfirm">Confirm Delete</label>
+                        </div>
                         <button type="submit" class="btn btn-primary">Connect</button>
                     </form>
                 </div>
@@ -81,6 +85,7 @@
                         sPrefix: $("#txtPrefix").val(),
                         sEndpoint: $("#txtEndpoint").val(),
                         bShowVersions: $("#chkVersions").is(":checked"),
+                        bConfirmDelete: $("#chkConfirm").is(":checked"),
                         iMaxFilesizeMB: 10240
                     });
 

--- a/s3commander.js
+++ b/s3commander.js
@@ -810,6 +810,7 @@ b64pad = "=";
         "files": new Object(),
         "folders": new Object(),
         "options": {
+          "confirmDelete": this.props.bConfirmDelete,
           "showDeletedFiles": false,
         }
       };
@@ -894,6 +895,13 @@ b64pad = "=";
         }.bind(this));
     },
     "onDeleteFolder": function(folder){
+      if(this.state.options.confirmDelete){
+        var msg = "Do you want to delete the " + folder.name + " folder?";
+        if (!window.confirm(msg)){
+          return;
+        }
+      }
+
       this.props.backend.deleteFolder(folder.path)
         .done(function(){
           this.onRefresh();
@@ -909,6 +917,13 @@ b64pad = "=";
       this.props.backend.downloadFile(file.path, version);
     },
     "onDeleteFile": function(file){
+      if(this.state.options.confirmDelete){
+        var msg = "Do you want to delete the " + file.name + " file?";
+        if (!window.confirm(msg)){
+          return;
+        }
+      }
+
       this.props.backend.deleteFile(file.path)
         .done(function(){
           this.onRefresh();
@@ -1019,6 +1034,7 @@ b64pad = "=";
     "sPrefix": "",
     "sEndpoint": "s3.amazonaws.com",
     "bShowVersions": false,
+    "bConfirmDelete": false,
     "iMaxFilesizeMB": 1024
   };
 


### PR DESCRIPTION
Add an optional JavaScript dialog to confirm if a user wants to delete a file or folder. The feature is toggled using the `bConfirmDelete` option.
