### PR TITLE
Raise a prompt when user attempts to navigate away while uploading

### DIFF
--- a/src/dropzone/DropzoneDirective.ts
+++ b/src/dropzone/DropzoneDirective.ts
@@ -48,6 +48,12 @@ export class DropzoneDirective implements ng.IDirective {
           // set form data prior to submitting the dz form
           scope.$ctrl.backend.updateFormData(scope.$ctrl.folder, file, formData);
         });
+
+        // enable prompt when user attempts to navigate away from this page
+        // while uploading a file
+        window.onbeforeunload = function() {
+          return true;
+        };
       },
       'success': function(file: any) {
         this.removeFile(file);
@@ -55,6 +61,9 @@ export class DropzoneDirective implements ng.IDirective {
       'queuecomplete': function() {
         // refresh folder contents
         scope.$ctrl.onRefresh({});
+
+        // disable prompt when user attempts to navigate away from this page
+        window.onbeforeunload = null;
       }
     };
 


### PR DESCRIPTION
This change has the browser create a prompt while a user is uploading a
file if they attempt to navigate away from the page. This helps prevent
the accidental cancellation of uploads.