### PR TITLE
Increase the limit of dropzone filesize to 100GB.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "web based object storage file browser",
   "homepage": "https://github.com/nimbis/s3commander",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/bucket/bucket.html
+++ b/src/bucket/bucket.html
@@ -69,6 +69,7 @@
       config="$ctrl.uploadConfig"
       folder="$ctrl.currentFolder"
       backend="$ctrl.backend"
+      working="$ctrl.working"
       on-refresh="$ctrl.loadContents()">
     </dropzone>
   </div>

--- a/src/dropzone/DropzoneComponent.ts
+++ b/src/dropzone/DropzoneComponent.ts
@@ -5,6 +5,7 @@ export const DropzoneComponent: angular.IComponentOptions = {
     config: '=',
     folder: '=',
     backend: '=',
+    working: '=',
     onRefresh: '&'
   },
   template: require('./dropzone.html'),

--- a/src/dropzone/DropzoneController.ts
+++ b/src/dropzone/DropzoneController.ts
@@ -19,6 +19,11 @@ export class DropzoneController {
   public backend: IBackend;
 
   /**
+   * Indicates S3Commander is working.
+   */
+  public working: boolean;
+
+  /**
    * Function to refresh bucket contents. This should be binded
    * to the 'loadContents' function in the parent scope.
    */

--- a/src/dropzone/DropzoneDirective.ts
+++ b/src/dropzone/DropzoneDirective.ts
@@ -33,7 +33,7 @@ export class DropzoneDirective implements ng.IDirective {
     // dropzone configuration
     let dropzoneConfig = {
       url: scope.$ctrl.config.url,
-      maxFilesize: 1024,
+      maxFilesize: 102400,
       addRemoveLinks: true,
       dictCancelUpload: 'Cancel',
       dictDefaultMessage: 'Click here or Drop files here to upload'

--- a/src/dropzone/DropzoneDirective.ts
+++ b/src/dropzone/DropzoneDirective.ts
@@ -36,7 +36,8 @@ export class DropzoneDirective implements ng.IDirective {
       maxFilesize: 102400,
       addRemoveLinks: true,
       dictCancelUpload: 'Cancel',
-      dictDefaultMessage: 'Click here or Drop files here to upload'
+      dictDefaultMessage: 'Click here or Drop files here to upload',
+      timeout: 0
     };
 
     // in order to allow access to 'scope' inside the dropzone

--- a/src/dropzone/DropzoneDirective.ts
+++ b/src/dropzone/DropzoneDirective.ts
@@ -56,10 +56,29 @@ export class DropzoneDirective implements ng.IDirective {
           return true;
         };
       },
+      'uploadprogress': function(file: any) {
+        // notify the bucket that we're working
+        if (scope.$ctrl.working != true) {
+          scope.$ctrl.working = true;
+        }
+      },
       'success': function(file: any) {
         this.removeFile(file);
       },
+      'error': function(file: any, errorMessage: string, xhr?: any) {
+        console.log('An error has occurred: ' + errorMessage);
+
+        if (xhr) {
+          console.log(xhr);
+        }
+      },
+      'reset': function() {
+        // notify the bucket that we're done working
+        scope.$ctrl.working = false;
+      },
       'queuecomplete': function() {
+        // notify the bucket that we're done working
+        scope.$ctrl.working = false;
         // refresh folder contents
         scope.$ctrl.onRefresh({});
 


### PR DESCRIPTION
This is a hotfix to let users upload larger files. This ideally should
be configurable through the API, but that feature will be implemented in
the future.