### PR TITLE
Add upload resume for aws uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "web based object storage file browser",
   "homepage": "https://github.com/nimbis/s3commander",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
Allow aws uploads to resume an existing mutipart upload.  This can occur if an upload is interrupted before it finishes.