### PR TITLE
Confirm the integrity of files with upload resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ When you're working with AWS S3 buckets you need to configure an appropriate COR
 </CORSConfiguration>
 ```
 
+AWS recommends configuring the bucket with a lifecycle rule to abort incomplete multipart uploads.  This will minimize your storage costs by removing the data for incomplete multipart uploads that may have been interrupted.
+
 The HTML file upload functionality uses an HTTPS API endpoint based on the bucket name (i.e. `https://<bucket>s3.amazonaws.com`). If the bucket name has dots (`.`) in the name this will fail because you can't use HTTPS with subdomains.
 
 ## Styling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,6 +1847,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -7004,7 +7009,7 @@
     },
     "localtunnel": {
       "version": "1.9.0",
-      "resolved": "http://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
       "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
       "dev": true,
       "requires": {
@@ -7031,7 +7036,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "web based object storage file browser",
   "homepage": "https://github.com/nimbis/s3commander",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
     "angular": "^1.7.4",
-    "aws-sdk": "^2.317.0"
+    "aws-sdk": "^2.317.0",
+    "crypto-js": "^3.1.9-1"
   },
   "devDependencies": {
     "@types/angular": "^1.6.50",


### PR DESCRIPTION
When resuming a multipart upload, compare the MD5 of existing parts on aws with corresponding parts from the uploading file to ensure upload integrity.