### PR TITLE
Update s3commander to version 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "web based object storage file browser",
   "homepage": "https://github.com/nimbis/s3commander",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
This will release will help to maintain s3commander as an individual
project. It is important to keep up with releases of projects for
this reason.