### PR TITLE
Add stylesheet for folder html

### DIFF
--- a/src/folder/folder.html
+++ b/src/folder/folder.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <div class="s3c-folder" ng-class="{'deleted': $ctrl.folder.deleted}">
   <i class="s3c-folder-icon"></i>
   <a ng-click="$ctrl.onNavigate()">{{ $ctrl.folder.path.name() }}</a>


### PR DESCRIPTION
Previously, an error existed where icons were not being displayed
for folders. This stylesheet addition allows the icons to be seen
again.