### PR TITLE
Allow sts sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3commander",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "web based object storage file browser",
   "homepage": "https://github.com/nimbis/s3commander",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/src/bucket/BucketComponent.ts
+++ b/src/bucket/BucketComponent.ts
@@ -9,7 +9,10 @@ export const BucketComponent: angular.IComponentOptions = {
     awsAccessKeyId: '=',
     awsSecretAccessKey: '=',
     awsSessionToken: '=?',
-    awsBucketPrefix: '=?'
+    awsBucketPrefix: '=?',
+    stsApiUrl: '=?',
+    stsHeaderName: '=?',
+    stsHeaderValue: '=?'
   },
   template: require('./bucket.html'),
   controller: BucketController

--- a/src/bucket/BucketComponent.ts
+++ b/src/bucket/BucketComponent.ts
@@ -8,6 +8,7 @@ export const BucketComponent: angular.IComponentOptions = {
     awsRegion: '=',
     awsAccessKeyId: '=',
     awsSecretAccessKey: '=',
+    awsSessionToken: '=?',
     awsBucketPrefix: '=?'
   },
   template: require('./bucket.html'),

--- a/src/bucket/BucketController.ts
+++ b/src/bucket/BucketController.ts
@@ -48,6 +48,11 @@ export class BucketController {
   public awsSecretAccessKey: string;
 
   /**
+   * AWS Session Token. Passed in as a component binding.
+   */
+  public awsSessionToken: string;
+
+  /**
    * AWS bucket prefix for a folder. Passed in as a component binding.
    */
   public awsBucketPrefix: string;
@@ -138,6 +143,11 @@ export class BucketController {
     }
     this.currentFolder = new Folder(new Path(this.awsBucketPrefix));
 
+    // default session token to None
+    if (this.awsSessionToken === undefined) {
+      this.awsSessionToken = null;
+    }
+
     // default allow download to true
     if (this.allowDownload === undefined) {
       this.allowDownload = true;
@@ -149,7 +159,7 @@ export class BucketController {
         this.awsRegion,
         this.awsAccessKeyId,
         this.awsSecretAccessKey,
-        null,
+        this.awsSessionToken,
         this.allowDownload);
     } else {
       throw new Error(`Unknown backend: ${this.backendName}`);

--- a/src/common/AmazonS3Backend.ts
+++ b/src/common/AmazonS3Backend.ts
@@ -34,12 +34,12 @@ export class AmazonS3Backend implements IBackend {
     sessionToken: string = null,
     allowDownload: boolean = true
   ) {
+    var creds = new AWS.Credentials(accessKeyId, secretAccessKey, sessionToken);
+
     this.s3 = new AWS.S3({
       apiVersion: 'latest',
       region: region,
-      accessKeyId: accessKeyId,
-      secretAccessKey: secretAccessKey,
-      sessionToken: sessionToken,
+      credentials: creds,
       sslEnabled: true,
       signatureVersion: 'v4'
     });


### PR DESCRIPTION
This enables the use of sts sessions via an API.  This will allow s3commander to be used with temporary credentials.