### PR TITLE
Test TypeScript linter passes on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - 'stable'
+script:
+  - gulp tslint


### PR DESCRIPTION
Currently, there aren't any unit tests for s3commander and the
tests fail when running `npm test`.

This commit defines the Travis script to run `gulp tslint` which
will only check if the code passes the typescript linter.